### PR TITLE
Fix release workflow to use `main` as release target branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           body: ${{steps.build_changelog.outputs.changelog}}
           prerelease: "${{ contains(github.ref, '-rc') }}"
-          # Ensure target branch for release is "master"
-          commit: master
+          # Ensure target branch for release is "main"
+          commit: main
           token: ${{ secrets.GITHUB_TOKEN }}
       # Create a bare v<major> tag, so that users can use our action with
       # @v<major>


### PR DESCRIPTION
Follow-up to fix copy-paste error in #13

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
