### PR TITLE
Switch `latestTag()` to discard all tags except for full SemVer tags

### DIFF
--- a/__tests__/version.test.ts
+++ b/__tests__/version.test.ts
@@ -56,7 +56,8 @@ describe('latestTag', () => {
       'v1.0.0',
       'v1.2.2',
       'foo-v1.0.0',
-      'bar'
+      'bar',
+      'v1'
     )
     getOctokitMock.mockImplementation(clientMock.mockFn)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -33530,7 +33530,7 @@ async function latestTag() {
     const tags = tagsResp
         .map(({ name }) => name)
         .filter(tag => {
-        return tag.startsWith('v');
+        return /^v\d+\.\d+\.\d+$/.test(tag);
     })
         .sort(semver_1.rcompare);
     const latest = tags.length === 0 ? 'v0.0.0' : tags[0];

--- a/src/version.ts
+++ b/src/version.ts
@@ -13,7 +13,7 @@ export async function latestTag(): Promise<string> {
   const tags = tagsResp
     .map(({ name }) => name)
     .filter(tag => {
-      return tag.startsWith('v')
+      return /^v\d+\.\d+\.\d+$/.test(tag)
     })
     .sort(rcompare)
 


### PR DESCRIPTION
We use the regex `^v\d+\.\d+\.\d+$` to only keep fully qualified SemVer tags when finding the newest tag. This ensures that the action also works on repos which have major-version tags.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
