### PR TITLE
Switch to `zyactions/update-semver@v1` to manage major-level tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,4 @@ jobs:
       # Create a bare v<major> tag, so that users can use our action with
       # @v<major>
       - name: Update SemVer tag
-        uses: rickstaa/action-update-semver@v1
-        with:
-          major_version_tag_only: true
+        uses: zyactions/update-semver@v1


### PR DESCRIPTION
The previous action (`rickstaa/action-update-semver@v1`) fails, cf. https://github.com/projectsyn/pr-label-tag-action/actions/runs/6770943536/job/18400350300

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
