### PR TITLE
Remove label `dependency` from non-major dev dependency update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "devDependencies (non-major)",
       "groupSlug": "dev-dependencies",
-      "labels": ["dependency"],
+      "labels": [],
       "automerge": true,
       "platformAutomerge": true,
       "extends": [ "schedule:weekly" ]


### PR DESCRIPTION
We don't need a bunch of "Update devDependencies (non-major)" entries in the changelog, so we remove the `dependency` label from those PRs.

Additionally, we set label `automerge` on PRs that get automerged.

## Checklist

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
